### PR TITLE
feat: optimization

### DIFF
--- a/chainhooks/marketplace.chainhook.yaml
+++ b/chainhooks/marketplace.chainhook.yaml
@@ -7,8 +7,8 @@ networks:
     devnet:
         predicate:
             print-event:
-                contract-identifier: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.cbtc-token
-                contains: vault
+                contract-identifier: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.nft-marketplace
+                contains: action
             # Also supports the following predicates:
             # nft-event:
             #     asset-identifier: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.cbtc-token::cbtc

--- a/contracts/marketplace-storage.clar
+++ b/contracts/marketplace-storage.clar
@@ -112,89 +112,73 @@
 )
 
 (define-read-only (get-fixed-price-listing-nonce)
-    (var-get fixed-price-nonce)
+  (var-get fixed-price-nonce)
 )
 
 (define-read-only (get-fixed-price-listing (listing-id uint))
-    (map-get? fixed-price-listings listing-id)
+  (map-get? fixed-price-listings listing-id)
 )
 
 (define-read-only (get-auction-nonce)
-    (var-get auction-nonce)
+  (var-get auction-nonce)
 )
 
 (define-read-only (get-previous-bid (auction-id uint) (bidder principal))
-    (default-to u0 (map-get? bids { auction-id: auction-id, bidder: bidder }))
+  (default-to u0 (map-get? bids { auction-id: auction-id, bidder: bidder }))
 )
 
 ;; Public Functions
 (define-public (increment-fixed-price-nonce)
-  (begin
-    (var-set fixed-price-nonce (+ (var-get fixed-price-nonce) u1))
-    (ok true)
-  )
+  (ok (var-set fixed-price-nonce (+ (var-get fixed-price-nonce) u1)))
 )
 
 (define-public (increment-auction-nonce)
-  (begin
-    (var-set auction-nonce (+ (var-get auction-nonce) u1))
-    (ok true)
-  )
+  (ok (var-set auction-nonce (+ (var-get auction-nonce) u1)))
 )
 
 (define-public (set-whitelisted (asset-contract principal) (whitelisted bool))
-  (begin
-    (ok (map-set whitelisted-asset-contracts asset-contract whitelisted))
-  )
+  (ok (map-set whitelisted-asset-contracts asset-contract whitelisted))
 )
 
 (define-public (set-owner (new-owner principal))
-  (begin
-    (var-set contract-owner new-owner)
-    (ok true)
-  )
+  (ok (var-set contract-owner new-owner))
 )
 
 (define-public (add-fixed-price-listing (listing-id uint) (listing { maker: principal, token-id: uint, nft-asset-contract: principal, price: uint }))
-  (begin
+  (ok
     (map-set fixed-price-listings listing-id {
         maker: (get maker listing), 
         nft-asset-contract: (get nft-asset-contract listing), 
         token-id: (get token-id listing), price: (get price listing)
     })
-    (ok true)
   )
 )
 
 
 
 (define-public (add-completed-fixed-price-listing (listing-id uint) (listing { maker: principal, token-id: uint, nft-asset-contract: principal, price: uint }))
-  (begin
+  (ok
     (map-set completed-fixed-price-listings listing-id {
         maker: (get maker listing), 
         nft-asset-contract: (get nft-asset-contract listing), 
         token-id: (get token-id listing), price: (get price listing)
     })
-    (ok true)
   )
 )
 
 (define-public (add-cancelled-fixed-price-listing (listing-id uint) (listing { maker: principal, token-id: uint, nft-asset-contract: principal, price: uint }))
-  (begin
+  (ok
     (map-set cancelled-fixed-price-listings listing-id {
         maker: (get maker listing), 
         nft-asset-contract: (get nft-asset-contract listing), 
         token-id: (get token-id listing), price: (get price listing)
     })
-    (ok true)
   )
 )
 
 (define-public (remove-fixed-price-listing (listing-id uint))
-    (begin
-        (map-delete fixed-price-listings listing-id)
-        (ok true)
-    )
+
+  (ok (map-delete fixed-price-listings listing-id))
 )
 
 (define-public (add-auction (auction-id uint) (auction {
@@ -208,7 +192,7 @@
     highest-bid: uint,
     highest-bidder: (optional principal)
   }))
- (begin
+ (ok
     (map-set auctions auction-id {
         maker: (get maker auction), 
         nft-asset-contract: (get nft-asset-contract auction), 
@@ -220,9 +204,7 @@
         highest-bid: (get highest-bid auction), 
         highest-bidder: (get highest-bidder auction)
     })
-
-    (ok true)
- )
+  )
 )
 
 (define-public (add-completed-auction (auction-id uint) (auction {
@@ -236,7 +218,7 @@
     highest-bid: uint,
     highest-bidder: (optional principal)
   }))
- (begin
+ (ok
     (map-set completed-auctions auction-id {
         maker: (get maker auction), 
         nft-asset-contract: (get nft-asset-contract auction), 
@@ -248,9 +230,7 @@
         highest-bid: (get highest-bid auction), 
         highest-bidder: (get highest-bidder auction)
     })
-
-    (ok true)
- )
+  )
 )
 
 (define-public (add-cancelled-auction (auction-id uint) (auction {
@@ -264,7 +244,7 @@
     highest-bid: uint,
     highest-bidder: (optional principal)
   }))
- (begin
+ (ok
     (map-set cancelled-auctions auction-id {
         maker: (get maker auction), 
         nft-asset-contract: (get nft-asset-contract auction), 
@@ -276,9 +256,7 @@
         highest-bid: (get highest-bid auction), 
         highest-bidder: (get highest-bidder auction)
     })
-
-    (ok true)
- )
+  )
 )
 
 (define-public (update-auction (auction-id uint) (auction {
@@ -292,7 +270,7 @@
     highest-bid: uint,
     highest-bidder: (optional principal)
   }))
- (begin
+ (ok
     (map-set auctions auction-id {
         maker: (get maker auction), 
         nft-asset-contract: (get nft-asset-contract auction), 
@@ -304,35 +282,21 @@
         highest-bid: (get highest-bid auction), 
         highest-bidder: (get highest-bidder auction)
     })
-
-    (ok true)
- )
+  )
 )
 
 (define-public (add-bid (key { auction-id: uint, bidder: principal }) (amount  uint))
-    (begin
-        (map-set bids { auction-id: (get auction-id key), bidder: (get bidder key) } amount)
-        (ok true)
-    )
+  (ok (map-set bids { auction-id: (get auction-id key), bidder: (get bidder key) } amount))
 )
 
 (define-public (add-withdrawn-bid (key { auction-id: uint, bidder: principal }) (amount  uint))
-    (begin
-        (map-set withdrawn-bids { auction-id: (get auction-id key), bidder: (get bidder key) } amount)
-        (ok true)
-    )
+  (ok (map-set withdrawn-bids { auction-id: (get auction-id key), bidder: (get bidder key) } amount))
 )
 
 (define-public (delete-bid (key { auction-id: uint, bidder: principal }))
-    (begin
-        (map-delete bids { auction-id: (get auction-id key), bidder: (get bidder key) })
-        (ok true)
-    )
+  (ok (map-delete bids { auction-id: (get auction-id key), bidder: (get bidder key) }))
 )
 
 (define-public (delete-auction (auction-id uint))
-    (begin
-        (map-delete auctions auction-id)
-        (ok true)
-    )
+  (ok (map-delete auctions auction-id))
 )


### PR DESCRIPTION
TODO: run tests

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
- Optimized the storage contract by removing `begin`.
- Running `clarinet check` and `clarinet test` failed and returned the following error 

`loading deployments/default.simnet-plan.yaml failed with error: error: /Users/amanzishan/Developer/taralDefi/nft-marketplace/deployments/default.simnet-plan.yaml syntax incorrect
unable to read file /Users/amanzishan/Developer/taralDefi/nft-marketplace/contracts\marketplace-storage.clar
Os { code: 2, kind: NotFound, message: "No such file or directory" }`

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `main` branch
- [ ] `yarn lint` passes with this change
- [ ] `yarn clarinet:check` passes with this change
- [ ] `yarn clarinet:tests` passes with this 
- [ ] `yarn unit-tests` passes with this
- [ ] Run `yarn eol`
- [ ] Run `yarn format`
- [ ] Run `yarn cleanup`
- [X] This pull request links relevant issues as `closes #1`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
